### PR TITLE
Add missing RepositorySessionDecorator requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven</artifactId>
-    <version>3.2.3</version>
+    <version>3.2.5</version>
   </parent>
 
   <groupId>info.evanchik.maven</groupId>

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -27,6 +27,11 @@
           <role-hint />
           <field-name>repoSystem</field-name>
         </requirement>
+        <requirement>
+          <role>org.apache.maven.project.RepositorySessionDecorator</role>
+          <role-hint />
+          <field-name>decorators</field-name>
+        </requirement>
       </requirements>
     </component>
   </components>


### PR DESCRIPTION
This is needed for Maven 3.2.5+.